### PR TITLE
fix: correct type definitions in index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-inheritance",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "vue inheritance",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,15 +1,65 @@
-export interface IExtendOptions {
+/**
+ * IVueComponent
+ * @description Interface for Vue component
+ * @interface
+ * @property {Object} emits - Vue emits
+ * @property {Object} props - Vue props
+ * @property {Object} methods - Vue methods
+ * @property {Object} computed - Vue computed
+ */
+export interface IVueComponent {
+  emits?: { [key: string]: any };
   props?: { [key: string]: any };
   methods?: { [key: string]: any };
   computed?: { [key: string]: any };
 }
 
-export declare class VueInheritance {
-  static extend(extendOptions: IExtendOptions): VueInheritance;
-  static implement(extendOptions: IExtendOptions): VueInheritance;
-  extend(extendOptions: IExtendOptions): VueInheritance;
-  implement(extendOptions: IExtendOptions): VueInheritance;
-  props?: { [key: string]: any };
-  methods?: { [key: string]: any };
-  computed?: { [key: string]: any };
+/**
+ * VueInheritanceComponent
+ * @description VueInheritanceComponent class
+ * @class
+ * @example
+ * const MyComponent = VueInheritance.extend(UIComponent).implement(IScrollable)
+ *  
+ */
+export interface VueInheritanceComponent extends IVueComponent {
+  /**
+   * extend
+   * @description Extend, Should only be used once
+   * @param component {IVueComponent} - Vue component
+   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   */
+  extend(component: IVueComponent): VueInheritanceComponent;
+  /**
+   * implement
+   * @param component {IVueComponent} - Vue component
+   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   */
+  implement(component: IVueComponent): VueInheritanceComponent;
 }
+
+/**
+ * VueInheritance
+ * @description VueInheritance
+ * @example
+ * const MyComponent = VueInheritance.extend(UIComponent).implement(IScrollable)
+ *  
+ */
+declare const VueInheritance: {
+
+  /**
+   * extend
+   * @description Extend, Should only be used once
+   * @param component {IVueComponent} - Vue component
+   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   */
+  extend(component: IVueComponent): VueInheritanceComponent;
+  /**
+   * implement
+   * @param component {IVueComponent} - Vue component
+   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   */
+  implement(component: IVueComponent): VueInheritanceComponent;
+}
+
+export default VueInheritance;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,48 +18,41 @@ export interface IVueComponent {
  * VueInheritanceComponent
  * @description VueInheritanceComponent class
  * @class
- * @example
- * const MyComponent = VueInheritance.extend(UIComponent).implement(IScrollable)
- *  
  */
-export interface VueInheritanceComponent extends IVueComponent {
-  /**
-   * extend
-   * @description Extend, Should only be used once
-   * @param component {IVueComponent} - Vue component
-   * @returns {VueInheritanceComponent} - VueInheritanceComponent
-   */
-  extend(component: IVueComponent): VueInheritanceComponent;
+export class VueInheritanceComponent {
   /**
    * implement
-   * @param component {IVueComponent} - Vue component
-   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   * @param {IVueComponent} interfaceDefine - Vue component
+   * @returns {VueInheritanceComponent} VueInheritanceComponent
    */
-  implement(component: IVueComponent): VueInheritanceComponent;
+  implement(interfaceDefine: IVueComponent): VueInheritanceComponent;
 }
 
 /**
  * VueInheritance
  * @description VueInheritance
  * @example
- * const MyComponent = VueInheritance.extend(UIComponent).implement(IScrollable)
- *  
+ * export default {
+ *  name: 'MyComponent',
+ *  extends: VueInheritance.extend(UIComponent).implement(IScrollable),
+ *  ...
+ * }
  */
 declare const VueInheritance: {
 
   /**
    * extend
    * @description Extend, Should only be used once
-   * @param component {IVueComponent} - Vue component
-   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   * @param {IVueComponent} componentDefine - Vue component
+   * @returns {VueInheritanceComponent} VueInheritanceComponent
    */
-  extend(component: IVueComponent): VueInheritanceComponent;
+  extend(componentDefine: IVueComponent): VueInheritanceComponent;
   /**
    * implement
-   * @param component {IVueComponent} - Vue component
-   * @returns {VueInheritanceComponent} - VueInheritanceComponent
+   * @param {IVueComponent} interfaceDefine - Vue component
+   * @returns {VueInheritanceComponent} VueInheritanceComponent
    */
-  implement(component: IVueComponent): VueInheritanceComponent;
+  implement(interfaceDefine: IVueComponent): VueInheritanceComponent;
 }
 
 export default VueInheritance;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 import { clone, isNil, isNotNil, has, isEmpty } from 'ramda'
 
 /**
- * Vue3Component
+ * VueInheritanceComponent
  * @class
  * @private
  * @author pedro.yang、 ocean.tsai
  * @description
  */
-class Vue3Component {
+class VueInheritanceComponent {
   /**
    * InvalidInterfaceKeys
    * @static
@@ -33,7 +33,7 @@ class Vue3Component {
    */
   static validateInterface (interfaceDefine) {
     // hasIn 是包含 prototype has 不會含 prototype
-    return Vue3Component.InvalidInterfaceKeys.every((key) => !has(key, interfaceDefine))
+    return VueInheritanceComponent.InvalidInterfaceKeys.every((key) => !has(key, interfaceDefine))
   }
 
   /**
@@ -49,7 +49,7 @@ class Vue3Component {
       throw new Error('Interface cannot be null or undefined.')
     } else if (isEmpty(interfaceDefine)) {
       throw new Error('Interface cannot be empty object.')
-    } else if (!Vue3Component.validateInterface(interfaceDefine)) {
+    } else if (!VueInheritanceComponent.validateInterface(interfaceDefine)) {
       throw new Error('The incoming parameter must be an interface.')
     }
   }
@@ -63,13 +63,13 @@ class Vue3Component {
    * @description
    */
   static extend (componentDefine, override) {
-    const vue3Component = isNotNil(componentDefine)
-      ? Object.assign(new Vue3Component(), clone(componentDefine))
-      : new Vue3Component()
+    const VueInheritanceComponent = isNotNil(componentDefine)
+      ? Object.assign(new VueInheritanceComponent(), clone(componentDefine))
+      : new VueInheritanceComponent()
 
     return isNotNil(override)
-      ? Object.assign(vue3Component, clone(override))
-      : vue3Component
+      ? Object.assign(VueInheritanceComponent, clone(override))
+      : VueInheritanceComponent
   }
 
   /**
@@ -81,8 +81,8 @@ class Vue3Component {
    * @description Vue's interface can only define props、methods.
    */
   static implement (interfaceDefine) {
-    Vue3Component.typeCheck(interfaceDefine)
-    return Vue3Component.extend(interfaceDefine)
+    VueInheritanceComponent.typeCheck(interfaceDefine)
+    return VueInheritanceComponent.extend(interfaceDefine)
   }
 
   // eslint-disable-next-line no-useless-constructor
@@ -105,7 +105,7 @@ class Vue3Component {
    * @description Vue's interface can only define props、methods.
    */
   implement (interfaceDefine) {
-    Vue3Component.typeCheck(interfaceDefine)
+    VueInheritanceComponent.typeCheck(interfaceDefine)
 
     if (isNil(this.extends) || isEmpty(this.extends)) {
       this.extends = clone(interfaceDefine)
@@ -128,8 +128,8 @@ class Vue3Component {
  * @description
  */
 const VueInheritance = Object.freeze({
-  extend: Vue3Component.extend,
-  implement: Vue3Component.implement
+  extend: VueInheritanceComponent.extend,
+  implement: VueInheritanceComponent.implement
 })
 
 export default VueInheritance


### PR DESCRIPTION
# correct type definitions and hints

### why: 
There was an issue with the type definitions in index.d.ts, which caused incorrect type hints and definitions.

<img width="726" alt="截圖 2024-09-02 上午10 24 03" src="https://github.com/user-attachments/assets/a39b466a-9f21-4fa2-94a8-a42f592d22d9">

### after this pr:
<img width="587" alt="截圖 2024-09-02 上午10 15 03" src="https://github.com/user-attachments/assets/a17505e4-4c96-487e-b69a-a23084714666">
<img width="887" alt="截圖 2024-09-02 上午10 15 29" src="https://github.com/user-attachments/assets/53b96119-893d-43f3-bfe1-9dbcbb9d8e94">

<img width="773" alt="截圖 2024-09-02 上午10 16 14" src="https://github.com/user-attachments/assets/d594b6ed-7b32-4545-931e-0e87f6428b05">
